### PR TITLE
fix: prevent duplicate toast listeners

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix toast hook effect dependencies

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `npm run lint` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aed896f008832dad14d457e274009d